### PR TITLE
Fixes a bug forcing login if not currently logged in

### DIFF
--- a/Changes.md
+++ b/Changes.md
@@ -94,3 +94,9 @@ Note - All hash comments refer to the issue number. Eg. #2 refers to https://git
 ### Changed
 
 - Allow to repeat date and time identifier in datetime format
+
+## [1.2.3] - 2026-06-21
+
+### Fixed
+
+- Fix forcing login if block added on site home page

--- a/classes/output/main.php
+++ b/classes/output/main.php
@@ -99,6 +99,10 @@ class main implements renderable, templatable {
             'helpbutton' => null,
         ];
 
+        if (!$context->userloggedin) {
+            unset($context->information['user']);
+        }
+
         return $context;
     }
 }

--- a/templates/main.mustache
+++ b/templates/main.mustache
@@ -483,11 +483,9 @@
                     {{#server}}
                         {{>block_timezoneclock/clock}}
                     {{/server}}
-                    {{#userloggedin}}
                     {{#user}}
                         {{>block_timezoneclock/clock}}
                     {{/user}}
-                    {{/userloggedin}}
                     {{#computer}}
                         {{>block_timezoneclock/clock}}
                     {{/computer}}
@@ -499,17 +497,16 @@
     {{/information}}
     {{#userloggedin}}
     <div class="converterform" id="{{formuniqid}}" data-form-class="{{{formclass}}}"{{!
-    }}data-user-loggedin="1" data-contextid="{{{ blockcontextid }}}"></div>
-    <div class="timezoneslist">
-            {{> block_timezoneclock/timezones }}
+    }} data-user-loggedin="1" data-contextid="{{{ blockcontextid }}}">
     </div>
     {{/userloggedin}}
+    <div class="timezoneslist">
+        {{> block_timezoneclock/timezones }}
+    </div>
 </div>
 {{#js}}
     require(['block_timezoneclock/main'], function(amd) {
         amd.initBlock('{{{dateformat}}}');
-        {{#userloggedin}}
         amd.registerForm('{{formuniqid}}', '{{{dateformat}}}');
-        {{/userloggedin}}
     });
 {{/js}}

--- a/templates/main.mustache
+++ b/templates/main.mustache
@@ -483,9 +483,11 @@
                     {{#server}}
                         {{>block_timezoneclock/clock}}
                     {{/server}}
+                    {{#userloggedin}}
                     {{#user}}
                         {{>block_timezoneclock/clock}}
                     {{/user}}
+                    {{/userloggedin}}
                     {{#computer}}
                         {{>block_timezoneclock/clock}}
                     {{/computer}}
@@ -495,17 +497,19 @@
         {{/toggler}}
     </div>
     {{/information}}
+    {{#userloggedin}}
     <div class="converterform" id="{{formuniqid}}" data-form-class="{{{formclass}}}"{{!
-    }}{{#userloggedin}} data-user-loggedin="1" {{/userloggedin}} data-contextid="{{{ blockcontextid }}}"></div>
+    }}data-user-loggedin="1" data-contextid="{{{ blockcontextid }}}"></div>
     <div class="timezoneslist">
-        {{#userloggedin}}
             {{> block_timezoneclock/timezones }}
-        {{/userloggedin}}
     </div>
+    {{/userloggedin}}
 </div>
 {{#js}}
     require(['block_timezoneclock/main'], function(amd) {
         amd.initBlock('{{{dateformat}}}');
+        {{#userloggedin}}
         amd.registerForm('{{formuniqid}}', '{{{dateformat}}}');
+        {{/userloggedin}}
     });
 {{/js}}

--- a/version.php
+++ b/version.php
@@ -24,9 +24,9 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026040501;
+$plugin->version   = 2026062100;
 $plugin->requires  = 2022041900;
 $plugin->supported = [400, 502];
 $plugin->component = 'block_timezoneclock';
 $plugin->maturity = MATURITY_STABLE;
-$plugin->release = 'v1.2.2';
+$plugin->release = 'v1.2.3';

--- a/version.php
+++ b/version.php
@@ -24,7 +24,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2026040500;
+$plugin->version   = 2026040501;
 $plugin->requires  = 2022041900;
 $plugin->supported = [400, 502];
 $plugin->component = 'block_timezoneclock';


### PR DESCRIPTION
Hello harshil8595,
We recently found a bug with this block which redirected logged out users to the login screen.
If the timezoneclock block was placed on the home page, and a user tried to view the page while logged out, they would be redirected to the login screen.
The issue seems to be related to the converter section being displayed and registering its form. This patch adds a condition to the template, only loading that section if the user is logged in. It also does the same for the "user" time section (based on the logged in users time preference).

Thanks!